### PR TITLE
move new files to an unredacted directory

### DIFF
--- a/redact_extract.py
+++ b/redact_extract.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import pdfplumber
 import fitz  # PyMuPDF
+from pathlib import Path
 
 
 def group_words_into_lines(words, line_tol=2.0):
@@ -210,13 +211,22 @@ def main():
     ap.add_argument("--min-spaces", type=int, default=1, help="Minimum spaces between words when gap exists")
     args = ap.parse_args()
 
+
+
     if not os.path.exists(args.input_pdf):
         raise FileNotFoundError(args.input_pdf)
 
     if args.output is None:
-        base, _ = os.path.splitext(args.input_pdf)
+        base_dir = os.path.dirname(args.input_pdf) # ex: ./files
+        new_folder = base_dir + "/unredacted/" # ex: ./files/unredacted/
+        pdf_name = Path(args.input_pdf).stem # ex: document1 (note: no extension)
         suffix = "_side_by_side.pdf" if args.mode == "side_by_side" else "_overlay_white.pdf"
-        args.output = base + suffix
+        args.output = new_folder + pdf_name + suffix # ex ./files/unredacted/document1_side_by_side.pdf
+
+        # create unredacted directory if not exists
+        if os.path.isdir(new_folder):
+            pass
+        else: os.makedirs(new_folder)
 
     if args.mode == "side_by_side":
         make_side_by_side(


### PR DESCRIPTION
Example: An unredacted version of `./base_path/document1.pdf` will now be written to  `./base_path/unredacted/document1_side_by_side.pdf` instead of `/base_path/document1_side_by_side.pdf` 

Hopefully improves batch running and file organization